### PR TITLE
Release 2.0

### DIFF
--- a/config/culpa.php
+++ b/config/culpa.php
@@ -18,13 +18,13 @@ return [
         | The default (commented) option should work for you if you are using the default Auth provider.
         | @see: https://github.com/laravel/framework/issues/9625
         |
-        | @return int|null User ID, or null if not authenticated
+        |  @return User model or null if not authenticated
         |
         |
 
         */
 //        'active_user' => function () {
-//            return Auth::check() ? Auth::user()->id : null;
+//            return Auth::check() ? Auth::user() : null;
 //        },
 
         /*

--- a/docs/1.2 Changing the user source.md
+++ b/docs/1.2 Changing the user source.md
@@ -14,12 +14,12 @@ An example of changing this configuration to sentry is shown below.
         | The default (commented) option should work for you if you are using the default Auth provider.
         | @see: https://github.com/laravel/framework/issues/9625
         |
-        | @return int|null User ID, or null if not authenticated
+        | @return User model or null if not authenticated
         |
         |
 
         'active_user' => function() {
-              return Sentry::check() ? Sentry::getUser()->id : null;
+              return Sentry::check() ? Sentry::getUser() : null;
         }
 ```
 

--- a/src/Contracts/CreatorAware.php
+++ b/src/Contracts/CreatorAware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Culpa\Contracts;
+
+interface CreatorAware
+{
+    /**
+     * Get the user that created the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model User instance
+     */
+    public function creator();
+}

--- a/src/Contracts/EraserAware.php
+++ b/src/Contracts/EraserAware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Culpa\Contracts;
+
+interface EraserAware
+{
+    /**
+     * Get the user that soft-deleted the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model User instance
+     */
+    public function eraser();
+}

--- a/src/Contracts/UpdaterAware.php
+++ b/src/Contracts/UpdaterAware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Culpa\Contracts;
+
+interface UpdaterAware
+{
+    /**
+     * Get the user that updated the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model User instance
+     */
+    public function updater();
+}

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -9,23 +9,24 @@ class Blueprint extends IlluminateBlueprint
      * Single method to configure all blameable fields in the table
      *
      * @param array $fields
+     * @param bool $nullable determine if the column can be NULL
+     * @throws \Exception
      * @see Blueprint::createdBy()
      * @see Blueprint::updatedBy()
      * @see Blueprint::deletedBy()
-     * @throws \Exception
      */
-    public function blameable($fields = array('created', 'updated', 'deleted'))
+    public function blameable($fields = array('created', 'updated', 'deleted'), $nullable = false)
     {
         if (in_array('created', $fields)) {
-            $this->createdBy();
+            $this->createdBy($nullable);
         }
 
         if (in_array('updated', $fields)) {
-            $this->updatedBy();
+            $this->updatedBy($nullable);
         }
 
         if (in_array('deleted', $fields)) {
-            $this->deletedBy();
+            $this->deletedBy($nullable);
         }
     }
 
@@ -33,10 +34,11 @@ class Blueprint extends IlluminateBlueprint
      * Add the blameable creator field
      *
      * @see Illuminate\Database\Schema\Blueprint::integer()
+     * @param bool $nullable determine if the column can be NULL
      * @return \Illuminate\Support\Fluent
      * @throws \Exception
      */
-    public function createdBy()
+    public function createdBy($nullable = false)
     {
         $columnName = Config::get('culpa.default_fields.created');
         if (!$columnName) {
@@ -44,6 +46,11 @@ class Blueprint extends IlluminateBlueprint
         }
 
         $field = $this->integer($columnName)->unsigned();
+
+        if (true === $nullable) {
+            $field->nullable();
+        }
+
         $this->addCulpaForeign($columnName);
 
         return $field;
@@ -53,10 +60,11 @@ class Blueprint extends IlluminateBlueprint
      * Add the blameable updater field
      *
      * @see Illuminate\Database\Schema\Blueprint::integer()
+     * @param bool $nullable determine if the column can be NULL
      * @return \Illuminate\Support\Fluent
      * @throws \Exception
      */
-    public function updatedBy()
+    public function updatedBy($nullable = false)
     {
         $columnName = Config::get('culpa.default_fields.updated');
         if (!$columnName) {
@@ -64,6 +72,11 @@ class Blueprint extends IlluminateBlueprint
         }
 
         $field = $this->integer($columnName)->unsigned();
+
+        if (true === $nullable) {
+            $field->nullable();
+        }
+
         $this->addCulpaForeign($columnName);
 
         return $field;
@@ -73,10 +86,11 @@ class Blueprint extends IlluminateBlueprint
      * Add the blameable eraser field
      *
      * @see Illuminate\Database\Schema\Blueprint::integer()
+     * @param bool $nullable determine if the column can be NULL
      * @return \Illuminate\Support\Fluent
      * @throws \Exception
      */
-    public function deletedBy()
+    public function deletedBy($nullable = false)
     {
         $columnName = Config::get('culpa.default_fields.deleted');
         if (!$columnName) {
@@ -84,6 +98,11 @@ class Blueprint extends IlluminateBlueprint
         }
 
         $field = $this->integer($columnName)->unsigned();
+
+        if (true === $nullable) {
+            $field->nullable();
+        }
+
         $this->addCulpaForeign($columnName);
 
         return $field;

--- a/src/Observers/BlameableObserver.php
+++ b/src/Observers/BlameableObserver.php
@@ -9,6 +9,9 @@
  */
 namespace Culpa\Observers;
 
+use Culpa\Contracts\CreatorAware;
+use Culpa\Contracts\EraserAware;
+use Culpa\Contracts\UpdaterAware;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Auth;
@@ -143,6 +146,10 @@ class BlameableObserver
     {
         $model->{$this->getColumn($model, 'created')} = $user->id;
 
+        if ($model instanceof CreatorAware) {
+            $model->setRelation('creator', $user);
+        }
+
         return $model;
     }
 
@@ -158,6 +165,10 @@ class BlameableObserver
     {
         $model->{$this->getColumn($model, 'updated')} = $user->id;
 
+        if ($model instanceof UpdaterAware) {
+            $model->setRelation('updater', $user);
+        }
+
         return $model;
     }
 
@@ -172,6 +183,10 @@ class BlameableObserver
     protected function setDeletedBy(Model $model, $user)
     {
         $model->{$this->getColumn($model, 'deleted')} = $user->id;
+
+        if ($model instanceof EraserAware) {
+            $model->setRelation('eraser', $user);
+        }
 
         return $model;
     }

--- a/src/Observers/BlameableObserver.php
+++ b/src/Observers/BlameableObserver.php
@@ -9,8 +9,10 @@
  */
 namespace Culpa\Observers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Auth;
+use ReflectionClass;
 
 class BlameableObserver
 {
@@ -22,7 +24,7 @@ class BlameableObserver
      *
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function creating($model)
+    public function creating(Model $model)
     {
         $this->updateBlameables($model);
     }
@@ -32,7 +34,7 @@ class BlameableObserver
      *
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function updating($model)
+    public function updating(Model $model)
     {
         $this->updateBlameables($model);
     }
@@ -42,60 +44,72 @@ class BlameableObserver
      *
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function deleting($model)
+    public function deleting(Model $model)
     {
         $this->updateDeleteBlameable($model);
     }
 
     /**
      * Update the blameable fields.
+     *
+     * @param Model $model
+     * @throws \Exception
      */
-    protected function updateBlameables($model)
+    protected function updateBlameables(Model $model)
     {
-        $user = $this->activeUser();
+        $user = $this->getActiveUser();
 
-        if ($user) {
-            // Set updated-by if it has not been touched on this model
-            if ($this->isBlameable($model, 'updated') && !$model->isDirty($this->getColumn($model, 'updated'))) {
-                $this->setUpdatedBy($model, $user);
-            }
+        if (is_null($user)) {
+            return; // Todo: might be wise to implement loggin here
+        }
 
-            // Set created-by if the model does not exist
-            if (
-                $this->isBlameable($model, 'created') && !$model->exists
-                && !$model->isDirty($this->getColumn($model, 'created'))
-            ) {
-                $this->setCreatedBy($model, $user);
-            }
+        // Set updated-by if it has not been touched on this model
+        if ($this->isBlameable($model, 'updated') && !$model->isDirty($this->getColumn($model, 'updated'))) {
+            $this->setUpdatedBy($model, $user);
+        }
+
+        // Determine if we need to touch the created stamp
+        if ($model->exists) {
+            return;
+        }
+
+        // Set created-by if the model does not exist
+        if ($this->isBlameable($model, 'created') && !$model->isDirty($this->getColumn($model, 'created'))) {
+            $this->setCreatedBy($model, $user);
         }
     }
 
     /**
      * Update the deletedBy blameable field.
+     * @param Model $model
+     * @throws \Exception
      */
-    public function updateDeleteBlameable($model)
+    public function updateDeleteBlameable(Model $model)
     {
-        $user = $this->activeUser();
+        $user = $this->getActiveUser();
 
-        if ($user) {
-            // Set deleted-at if it has not been touched
-            if ($this->isBlameable($model, 'deleted') && !$model->isDirty($this->getColumn($model, 'deleted'))) {
-                $this->setDeletedBy($model, $user);
-                $model->save();
-            }
+        if (is_null($user)) {
+            return;
         }
+
+        // Set deleted-at if it has not been touched
+        if ($this->isBlameable($model, 'deleted') && !$model->isDirty($this->getColumn($model, 'deleted'))) {
+            $this->setDeletedBy($model, $user);
+            $model->save();
+        }
+
     }
 
     /**
      * Get the active user.
      *
-     * @return int User ID
+     * @return User
      * @throws \Exception
      */
-    protected function activeUser()
+    protected function getActiveUser()
     {
         if (!Config::has('culpa.users.active_user')) {
-            return Auth::check() ? Auth::user()->id : null;
+            return Auth::check() ? Auth::user() : null;
         }
 
         $fn = Config::get('culpa.users.active_user');
@@ -107,16 +121,27 @@ class BlameableObserver
     }
 
     /**
+     * Get the id of the active user
+     *
+     * @return int User ID
+     * @throws \Exception
+     */
+    protected function getActiveUserIdentifier()
+    {
+        return $this->getActiveUser()->id;
+    }
+
+    /**
      * Set the created-by field of the model.
      *
      * @param \Illuminate\Database\Eloquent\Model $model
-     * @param int $user
+     * @param User $user
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    protected function setCreatedBy($model, $user)
+    protected function setCreatedBy(Model $model, $user)
     {
-        $model->{$this->getColumn($model, 'created')} = $user;
+        $model->{$this->getColumn($model, 'created')} = $user->id;
 
         return $model;
     }
@@ -125,13 +150,13 @@ class BlameableObserver
      * Set the updated-by field of the model.
      *
      * @param \Illuminate\Database\Eloquent\Model $model
-     * @param int $user
+     * @param User $user
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    protected function setUpdatedBy($model, $user)
+    protected function setUpdatedBy(Model $model, $user)
     {
-        $model->{$this->getColumn($model, 'updated')} = $user;
+        $model->{$this->getColumn($model, 'updated')} = $user->id;
 
         return $model;
     }
@@ -140,13 +165,13 @@ class BlameableObserver
      * Set the deleted-by field of the model.
      *
      * @param \Illuminate\Database\Eloquent\Model $model
-     * @param int $user
+     * @param User $user
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    protected function setDeletedBy($model, $user)
+    protected function setDeletedBy(Model $model, $user)
     {
-        $model->{$this->getColumn($model, 'deleted')} = $user;
+        $model->{$this->getColumn($model, 'deleted')} = $user->id;
 
         return $model;
     }
@@ -158,15 +183,15 @@ class BlameableObserver
      *
      * @return string|null
      */
-    public function getColumn($model, $event)
+    public function getColumn(Model $model, $event)
     {
-        if (array_key_exists($event, $this->getBlameableFields($model))) {
-            $fields = $this->getBlameableFields($model);
-
-            return $fields[$event];
-        } else {
+        if (!array_key_exists($event, $this->getBlameableFields($model))) {
             return;
         }
+
+        $fields = $this->getBlameableFields($model);
+
+        return $fields[$event];
     }
 
     /**
@@ -176,7 +201,7 @@ class BlameableObserver
      *
      * @return bool
      */
-    public function isBlameable($model, $event = null)
+    public function isBlameable(Model $model, $event = null)
     {
         return $event ?
             array_key_exists($event, $this->getBlameableFields($model)) :
@@ -194,15 +219,14 @@ class BlameableObserver
      *   private $blameable = ['created' => 'author_id'];
      *   private $blameable = ['created', 'updated', 'deleted' => 'killedBy'];
      *
-     * @param array|null $fields Optionally, the $blameable array can be given rather than using reflection
-     *
-     * @return array
+     * @param Model $model
+     * @param array|null $blameable Optionally, the $blameable array can be given rather than using reflection
+     * @return array array of blameable fields
      */
-    public static function findBlameableFields($model, $blameable = null)
+    public static function findBlameableFields(Model $model, $blameable = array())
     {
-        if (is_null($blameable)) {
-            // Get the reflected model instance in order to access $blameable
-            $reflectedModel = new \ReflectionClass($model);
+        if (empty($blameable)) {
+            $reflectedModel = new ReflectionClass($model);
             if (!$reflectedModel->hasProperty('blameable')) {
                 return array();
             }
@@ -250,9 +274,10 @@ class BlameableObserver
     /**
      * Get the blameable fields.
      *
+     * @param Model $model
      * @return array
      */
-    protected function getBlameableFields($model)
+    protected function getBlameableFields(Model $model)
     {
         if (isset($this->fields)) {
             return $this->fields;

--- a/src/Traits/Blameable.php
+++ b/src/Traits/Blameable.php
@@ -39,7 +39,9 @@ trait Blameable
     protected function getFields()
     {
         // Abort if blameble has been disabled explicitly
-        if($this->blameable === false) return false;
+        if (false === $this->blameable) {
+            return false;
+        }
 
         if (!isset($this->fields)) {
             $this->fields = BlameableObserver::findBlameableFields($this, $this->blameable);

--- a/tests/FullyBlameableTest.php
+++ b/tests/FullyBlameableTest.php
@@ -28,7 +28,7 @@ class FullyBlameableTest extends CulpaTest
         $this->model->title = 'Hello, world!';
         $this->assertTrue($this->model->save());
 
-        $this->model = FullyBlameableModel::find($this->model->id);
+        $this->model = $this->model->fresh();
 
         // Check datetimes are being set properly for sanity's sake
         $this->assertNotNull($this->model->created_at);
@@ -52,7 +52,7 @@ class FullyBlameableTest extends CulpaTest
         // Make sure updated_at > created_at by at least 1 second
         usleep(1.5 * 1000000); // 1.5 seconds
 
-        $this->model = FullyBlameableModel::find(1);
+        $this->model = $this->model->fresh();
         $this->model->title = 'Test Post, please ignore';
         $this->assertTrue($this->model->save());
 
@@ -73,17 +73,17 @@ class FullyBlameableTest extends CulpaTest
     {
         $this->model->title = 'Hello, world!';
         $this->assertTrue($this->model->save());
-
-        $this->model = FullyBlameableModel::find(1);
+        usleep(1.5 * 1000000); // 1.5 seconds
         $this->assertTrue($this->model->delete());
 
         // Reload the model
-        $this->model = FullyBlameableModel::withTrashed()->find(1);
+        $this->model = $this->model->withTrashed()->find($this->model->id);
 
         // Check datetimes are being set properly for sanity's sake
         $this->assertNotNull($this->model->created_at);
-        $this->assertGreaterThan($this->model->created_at, $this->model->updated_at);
+        $this->assertNotNull($this->model->updated_at);
         $this->assertNotNull($this->model->deleted_at);
+        $this->assertGreaterThan($this->model->created_at, $this->model->deleted_at);
 
         $this->assertEquals(1, $this->model->created_by);
         $this->assertEquals(1, $this->model->updated_by);

--- a/tests/ModelAwareTest.php
+++ b/tests/ModelAwareTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Culpa\Tests;
+
+use Culpa\Contracts\CreatorAware;
+use Culpa\Contracts\EraserAware;
+use Culpa\Contracts\UpdaterAware;
+use Culpa\Tests\Models\FullyBlameableAwareModel;
+
+class ModelAwareTest extends FullyBlameableTest
+{
+    private $model;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->model = new FullyBlameableAwareModel();
+    }
+
+    public function testHasInterfaces()
+    {
+        $this->assertTrue($this->model instanceof CreatorAware);
+        $this->assertTrue($this->model instanceof UpdaterAware);
+        $this->assertTrue($this->model instanceof EraserAware);
+    }
+}

--- a/tests/Models/FullyBlameableAwareModel.php
+++ b/tests/Models/FullyBlameableAwareModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Culpa\Tests\Models;
+
+use Culpa\Contracts\CreatorAware;
+use Culpa\Contracts\EraserAware;
+use Culpa\Contracts\UpdaterAware;
+use Culpa\Traits\Blameable;
+use Culpa\Traits\CreatedBy;
+use Culpa\Traits\DeletedBy;
+use Culpa\Traits\UpdatedBy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * A model with all 3 fields, with the default values and the aware interfaces
+ */
+class FullyBlameableAwareModel extends Model implements CreatorAware, UpdaterAware, EraserAware
+{
+    use CreatedBy, UpdatedBy, DeletedBy, Blameable, SoftDeletes;
+    protected $table = 'posts';
+    protected $blameable = array('created', 'updated', 'deleted');
+}

--- a/tests/SchemaBlueprintTest.php
+++ b/tests/SchemaBlueprintTest.php
@@ -5,7 +5,6 @@ namespace Culpa\Tests;
 use Culpa\Database\Schema\Blueprint;
 use Culpa\Tests\Bootstrap\CulpaTest;
 use Illuminate\Database\Schema\Builder;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Due to protected methods called from the constructor, i was having trouble to test the actual booting of the Trait.
@@ -17,6 +16,11 @@ class SchemaBlueprintTest extends CulpaTest
      * @var string
      */
     private $tableName = 'testTable';
+
+    /**
+     * @var string
+     */
+    protected $columnName = 'column1';
 
     /**
      * @var Builder
@@ -50,6 +54,27 @@ class SchemaBlueprintTest extends CulpaTest
     }
 
     /**
+     * The CreatedBy method in the blueprint class should create a new created_by column that is nullable
+     */
+    public function testCreatedByNullable()
+    {
+        $columnName = $this->columnName;
+        $this->schemaBuilder->create($this->tableName, function (Blueprint $table) use ($columnName) {
+            $table->text($columnName);
+            $table->createdBy(true);
+        });
+
+        $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, $columnName));
+        $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, 'created_by'));
+
+        static::$app->make('db')->connection()->insert(
+            'INSERT INTO ' . $this->tableName . '(' . $columnName . ') VALUES ("testing feature...")'
+        );
+        $results = static::$app->make('db')->connection()->select('SELECT * FROM ' . $this->tableName);
+        $this->assertEquals(1, count($results));
+    }
+
+    /**
      * The updatedBy method in the blueprint class should create a new updated_by column
      */
     public function testUpdatedBy()
@@ -59,6 +84,29 @@ class SchemaBlueprintTest extends CulpaTest
         });
 
         $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, 'updated_by'));
+    }
+
+
+    /**
+     * The updatedBy method in the blueprint class should create a new updated_by column that is nullable
+     */
+    public function testUpdatedByNullable()
+    {
+        $columnName = $this->columnName;
+        $this->schemaBuilder->create($this->tableName, function (Blueprint $table) use ($columnName) {
+            $table->text($columnName);
+            $table->updatedBy(true);
+        });
+
+        $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, $columnName));
+        $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, 'updated_by'));
+
+        static::$app->make('db')->connection()->insert(
+            'INSERT INTO ' . $this->tableName . '(' . $columnName . ') VALUES ("testing feature...")'
+        );
+
+        $results = static::$app->make('db')->connection()->select('SELECT * FROM ' . $this->tableName);
+        $this->assertEquals(1, count($results));
     }
 
     /**
@@ -71,6 +119,28 @@ class SchemaBlueprintTest extends CulpaTest
         });
 
         $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, 'deleted_by'));
+    }
+
+    /**
+     * The deletedBy method in the blueprint class should create a new deleted_by column that is nullable
+     */
+    public function testDeletedByNullable()
+    {
+        $columnName = $this->columnName;
+        $this->schemaBuilder->create($this->tableName, function (Blueprint $table) use ($columnName) {
+            $table->text($columnName);
+            $table->deletedBy(true);
+        });
+
+        $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, $columnName));
+        $this->assertTrue($this->schemaBuilder->hasColumn($this->tableName, 'deleted_by'));
+
+        static::$app->make('db')->connection()->insert(
+            'INSERT INTO ' . $this->tableName . '(' . $columnName . ') VALUES ("testing feature...")'
+        );
+
+        $results = static::$app->make('db')->connection()->select('SELECT * FROM ' . $this->tableName);
+        $this->assertEquals(1, count($results));
     }
 
     /**


### PR DESCRIPTION
### Changes
- Add nullable to the Schema builder
- Introduced interfaces you can use to indicate that your model is using certain traits
### Backwards compatibility

backward compactibility is broken due to:
-  changes in the `culpa.users.active_user` configuration, which now returns a user instead of an identifier
- The bleameable trait no longer works on models who arent extending from the Eloquent model. I've type hinted them because i needed more consistency in the code.
